### PR TITLE
Add regression test: non-owner editor cannot edit exploration

### DIFF
--- a/core/controllers/acl_decorators_test.py
+++ b/core/controllers/acl_decorators_test.py
@@ -3356,7 +3356,20 @@ class EditExplorationTests(test_utils.GenericTestBase):
             )
         error_msg = 'You must be logged in to access this resource.'
         self.assertEqual(response['error'], error_msg)
-
+        
+    def test_non_owner_editor_cannot_edit_exploration(self) -> None:
+        self.signup('other_editor@test.com', 'othereditor')
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.login('other_editor@test.com')
+            response = self.get_json(
+                '/mock_edit_exploration/%s' % self.private_exp_id,
+                expected_status_int=401,
+            )
+        self.assertEqual(
+            response['error'],
+            'You do not have credentials to edit this exploration.'
+        )
+        self.logout()
 
 class ManageOwnAccountTests(test_utils.GenericTestBase):
     """Tests for decorator can_manage_own_account."""

--- a/docs/reviews/PR-3-self-review.md
+++ b/docs/reviews/PR-3-self-review.md
@@ -1,0 +1,28 @@
+# PR-3 Self-Review: Add regression test — non-owner editor cannot edit exploration
+
+## What changed and why?
+Added `test_non_owner_editor_cannot_edit_exploration` to `EditExplorationTests`
+in `core/controllers/acl_decorators_test.py`. The existing tests covered owner
+allowed, guest denied, and banned user denied — but not the case where another
+authenticated user attempts to edit an exploration they do not own. This is the
+lateral privilege escalation gap.
+
+## Why is this the right test layer?
+Integration level is correct here. The goal is to validate that the
+`can_edit_exploration` decorator correctly rejects an authenticated but
+unauthorized user through the full decorator chain — no mocks, no shortcuts.
+
+## What could still break / what is not covered?
+- The `can_save_exploration` decorator has the same gap and is not covered by
+  this PR
+- Only the private exploration case is tested; the published exploration case
+  for a non-owner is not explicitly tested here (though moderators can edit
+  published explorations, a plain other_editor cannot)
+
+## What risks or follow-ups remain?
+- A follow-up PR could add the same test to `SaveExplorationTests` for
+  completeness
+- The issue acceptance criteria listed 403 as the expected status code, but the
+  codebase actually returns 401 for `UnauthorizedUserException` — this is
+  correct behavior and the test reflects reality, but the issue description
+  should be noted as inaccurate on that point


### PR DESCRIPTION
## Overview

## Summary
Closes #3

Adds a regression test to `EditExplorationTests` in `core/controllers/acl_decorators_test.py` verifying that an authenticated user who does not own an exploration cannot edit it via the editor endpoint.

## What Changed
- Added `test_non_owner_editor_cannot_edit_exploration` to `EditExplorationTests`
- Signs up a second user (`other_editor@test.com`) who has no rights to the owner's exploration
- Asserts the decorator returns 401 with the correct error message

## How to Run
python -m scripts.run_backend_tests --test_targets=core.controllers.acl_decorators_test.EditExplorationTests

Expected: `Ran 8 tests in ~23s OK`

## What Is Now Protected
Before this PR, a refactor to `can_edit_exploration` that accidentally granted access based on "is the user authenticated?" rather than "is the user authorized for this specific exploration?" would pass all existing tests undetected. This test catches that lateral privilege escalation regression.



<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: [Explain here what your PR does and why]
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
