### PR TITLE
Add backend shard registration check to CI validation

### DIFF
--- a/docs/reviews/PR-11-self-review.md
+++ b/docs/reviews/PR-11-self-review.md
@@ -1,0 +1,45 @@
+# Self-Review: PR #11 — Add backend shard registration check to CI validation
+
+## What changed and why?
+
+Extended `scripts/check_tests_are_captured_in_ci.py` with a new function
+`get_unregistered_backend_test_modules()` that scans all `*_test.py` files
+on disk across `core/`, `scripts/`, `extensions/`, and the repo root, then
+diffs them against every module registered in `scripts/backend_test_shards.json`.
+
+Before this change, a developer could create a backend test file and forget
+to register it in the shards file. CI would run silently and those tests
+would never execute — invisible coverage loss with no warning anywhere.
+This check catches that gap at CI time and emits an actionable error message
+naming each missing module and linking to the wiki.
+
+Also registered two real modules discovered by the new check that were
+previously missing from the shards file:
+
+- `core.tests.build_sources.extensions.base_test`
+- `core.tests.build_sources.extensions.models_test`
+
+## Why is this the right test layer?
+
+This is infrastructure/script testing, not production code testing.
+The right layer is a unit test of the checker script itself, run inside
+the backend test suite. The three new tests in
+`check_tests_are_captured_in_ci_test.py` test exactly the three behaviors
+that matter: passing case, failing case, and root-level file handling.
+
+## What could still break / what is not covered?
+
+- If a new top-level directory is added for test files and is not in
+  `dirs_to_scan`, files there will not be caught. That requires a manual
+  update to the constant in the function.
+- The inverse check (shard entries pointing to files that no longer exist
+  on disk) is not implemented. A ghost entry would cause `run_backend_tests.py`
+  to fail with a cryptic import error rather than a clean message.
+
+## What risks or follow-ups remain?
+
+- Follow-up: add ghost-entry detection (shard entries with no corresponding
+  file on disk).
+- The 14 pre-existing test errors in `CheckTestsAreCapturedInCiTest` are a
+  local environment issue (duplicate superadmin user in test datastore) and
+  are not caused by this PR. All 3 new tests pass cleanly.

--- a/scripts/backend_test_shards.json
+++ b/scripts/backend_test_shards.json
@@ -204,7 +204,9 @@
         "core.jobs.batch_jobs.question_migration_jobs_test",
         "core.jobs.batch_jobs.subtopic_migration_jobs_test",
         "core.jobs.batch_jobs.reject_invalid_suggestion_and_delete_invalid_translation_jobs_test",
-        "core.domain.voiceover_cloud_task_services_test"
+        "core.domain.voiceover_cloud_task_services_test",
+        "core.tests.build_sources.extensions.base_test",
+        "core.tests.build_sources.extensions.models_test"
     ],
     "4": [
         "core.storage.learner_group.gae_models_test",

--- a/scripts/check_tests_are_captured_in_ci.py
+++ b/scripts/check_tests_are_captured_in_ci.py
@@ -27,7 +27,9 @@ from typing import List, TypedDict
 
 E2E_TEST_SUITES_THAT_ARE_NOT_RUN_IN_CI = ['full']
 ACCEPTANCE_TEST_SUITES_THAT_ARE_NOT_RUN_IN_CI: List[str] = []
-
+BACKEND_TEST_SHARDS_FILE_PATH = os.path.join(
+    os.getcwd(), 'scripts', 'backend_test_shards.json'
+)
 
 CI_TEST_SUITE_CONFIGS_DIRECTORY = os.path.join(
     os.getcwd(), 'core', 'tests', 'ci-test-suite-configs'
@@ -217,6 +219,43 @@ def get_acceptance_test_suites_from_acceptance_directory() -> (
     return sorted(acceptance_test_suites, key=lambda x: x['name'])
 
 
+def get_unregistered_backend_test_modules() -> List[str]:
+    """Returns backend *_test.py modules missing from backend_test_shards.json.
+
+    Scans all *_test.py files under core/, scripts/, extensions/, and the
+    repo root, converts each file path to a dotted module path, then compares
+    against every module registered in scripts/backend_test_shards.json.
+
+    Returns:
+        list(str). Sorted list of module paths that exist on disk but are
+        not registered in any shard, e.g. ['core.domain.new_feature_test'].
+    """
+    with open(BACKEND_TEST_SHARDS_FILE_PATH, 'r', encoding='utf-8') as f:
+        shards_data = json.load(f)
+
+    registered_modules: set = set()
+    for shard_list in shards_data.values():
+        registered_modules.update(shard_list)
+
+    discovered_modules: set = set()
+
+    dirs_to_scan = ['core', 'scripts', 'extensions']
+    for scan_dir in dirs_to_scan:
+        for dirpath, _, filenames in os.walk(scan_dir):
+            for filename in filenames:
+                if filename.endswith('_test.py'):
+                    filepath = os.path.join(dirpath, filename)
+                    module = filepath.replace(os.sep, '.')[: -len('.py')]
+                    discovered_modules.add(module)
+
+    for filename in os.listdir('.'):
+        if filename.endswith('_test.py'):
+            module = filename[: -len('.py')]
+            discovered_modules.add(module)
+
+    return sorted(discovered_modules - registered_modules)
+
+
 def compute_test_suites_difference(
     test_suites_from_config: List[TestSuiteDict],
     test_suites_from_directory: List[TestSuiteDict],
@@ -310,6 +349,22 @@ def main() -> None:
             'suites are not in sync: %s. Please update the CI config file for '
             'e2e tests at core/tests/ci-test-suite-configs/e2e.json with the '
             'suites listed above.' % (json.dumps(e2e_test_suites_difference))
+        )
+    print('Done!')
+
+    print(
+        'Checking all backend test modules are registered in '
+        'backend_test_shards.json...'
+    )
+    unregistered_modules = get_unregistered_backend_test_modules()
+    if len(unregistered_modules) > 0:
+        raise Exception(
+            'The following backend test modules exist on disk but are not '
+            'registered in any shard in scripts/backend_test_shards.json:\n'
+            '%s\n'
+            'Please add each module to the appropriate shard. See: '
+            'https://github.com/oppia/oppia/wiki/Backend-tests#shards'
+            % '\n'.join('  ' + m for m in unregistered_modules)
         )
     print('Done!')
 

--- a/scripts/check_tests_are_captured_in_ci_test.py
+++ b/scripts/check_tests_are_captured_in_ci_test.py
@@ -466,3 +466,97 @@ class CheckTestsAreCapturedInCiTest(test_utils.GenericTestBase):
                         with get_e2e_test_suites_from_ci_config_file_swap:
                             with get_e2e_test_suites_from_webdriverio_config_file_swap:  # pylint: disable=line-too-long
                                 check_tests_are_captured_in_ci.main()
+
+
+class GetUnregisteredBackendTestModulesTest(test_utils.GenericTestBase):
+    """Tests for get_unregistered_backend_test_modules."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+        self.shards_file = os.path.join(self.temp_dir.name, 'shards.json')
+        with open(self.shards_file, 'w', encoding='utf-8') as f:
+            json.dump({'1': ['core.domain.foo_test']}, f)
+
+        self.shards_file_swap = self.swap(
+            check_tests_are_captured_in_ci,
+            'BACKEND_TEST_SHARDS_FILE_PATH',
+            self.shards_file,
+        )
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.temp_dir.cleanup()
+
+    def test_returns_empty_list_when_all_modules_registered(self) -> None:
+        def mock_walk(path: str) -> List:  # pylint: disable=unused-argument
+            if path == 'core':
+                return iter([('core/domain', [], ['foo_test.py'])])
+            return iter([])
+
+        def mock_listdir(
+            path: str,
+        ) -> List[str]:  # pylint: disable=unused-argument
+            return []
+
+        os_walk_swap = self.swap(os, 'walk', mock_walk)
+        os_listdir_swap = self.swap(os, 'listdir', mock_listdir)
+
+        with self.shards_file_swap:
+            with os_walk_swap:
+                with os_listdir_swap:
+                    result = (
+                        check_tests_are_captured_in_ci.get_unregistered_backend_test_modules()
+                    )
+        self.assertEqual(result, [])
+
+    def test_returns_module_missing_from_shards(self) -> None:
+        def mock_walk(path: str) -> List:  # pylint: disable=unused-argument
+            if path == 'core':
+                return iter(
+                    [
+                        (
+                            'core/domain',
+                            [],
+                            ['foo_test.py', 'new_feature_test.py'],
+                        )
+                    ]
+                )
+            return iter([])
+
+        def mock_listdir(
+            path: str,
+        ) -> List[str]:  # pylint: disable=unused-argument
+            return []
+
+        os_walk_swap = self.swap(os, 'walk', mock_walk)
+        os_listdir_swap = self.swap(os, 'listdir', mock_listdir)
+
+        with self.shards_file_swap:
+            with os_walk_swap:
+                with os_listdir_swap:
+                    result = (
+                        check_tests_are_captured_in_ci.get_unregistered_backend_test_modules()
+                    )
+        self.assertEqual(result, ['core.domain.new_feature_test'])
+
+    def test_returns_unregistered_root_level_module(self) -> None:
+        def mock_walk(path: str) -> List:  # pylint: disable=unused-argument
+            return iter([])
+
+        def mock_listdir(
+            path: str,
+        ) -> List[str]:  # pylint: disable=unused-argument
+            return ['new_root_test.py', 'readme.md']
+
+        os_walk_swap = self.swap(os, 'walk', mock_walk)
+        os_listdir_swap = self.swap(os, 'listdir', mock_listdir)
+
+        with self.shards_file_swap:
+            with os_walk_swap:
+                with os_listdir_swap:
+                    result = (
+                        check_tests_are_captured_in_ci.get_unregistered_backend_test_modules()
+                    )
+        self.assertEqual(result, ['new_root_test'])


### PR DESCRIPTION
Extends check_tests_are_captured_in_ci.py to verify that every backend *_test.py file on disk is registered in at least one shard in scripts/backend_test_shards.json.

Before this change, a developer could add a new test file and forget to register it in the shards file. CI would run without error but the new tests would never execute -- silent coverage loss with no warning.

Also registers two previously unregistered test modules discovered by the new check:
  core.tests.build_sources.extensions.base_test
  core.tests.build_sources.extensions.models_test

Closes #5

## Problem
If a developer adds a new `*_test.py` file and forgets to register it
in `scripts/backend_test_shards.json`, CI runs without error but those
tests never execute. This is silent coverage loss with no warning anywhere.

## What changed
- Extended `scripts/check_tests_are_captured_in_ci.py` with a new function
  `get_unregistered_backend_test_modules()` that scans all `*_test.py` files
  on disk and diffs them against `backend_test_shards.json`
- Wired the check into `main()` with a clear, actionable error message
- Added 3 tests in `check_tests_are_captured_in_ci_test.py` covering:
  - All modules registered (passes cleanly)
  - Missing module detected (catches the bug)
  - Root-level test files handled correctly
- Registered 2 previously unregistered modules discovered by the new check:
  `core.tests.build_sources.extensions.base_test`
  `core.tests.build_sources.extensions.models_test`

## How to run
python -m scripts.check_tests_are_captured_in_ci

## Evidence
Before this PR: adding a `*_test.py` file without registering it in shards
produced no CI error. After this PR: the check fails immediately with the
name of every unregistered module and a link to the wiki.



## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: [Explain here what your PR does and why]
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
