### PR TITLE
630:P1 Add learner progress edge-case tests (Closes #2)

### DIFF
--- a/core/domain/learner_progress_services_test.py
+++ b/core/domain/learner_progress_services_test.py
@@ -1020,6 +1020,66 @@ class LearnerProgressTests(test_utils.GenericTestBase):
             [self.EXP_ID_0, self.EXP_ID_3],
         )
 
+    def test_completing_exploration_twice_does_not_duplicate_it(self) -> None:
+
+        self.assertEqual(self._get_all_completed_exp_ids(self.user_id), [])
+
+        learner_progress_services.mark_exploration_as_completed(
+            self.user_id, self.EXP_ID_0
+        )
+        learner_progress_services.mark_exploration_as_completed(
+            self.user_id, self.EXP_ID_0
+        )
+
+        completed_ids = self._get_all_completed_exp_ids(self.user_id)
+        self.assertEqual(len(completed_ids), 1)
+        self.assertEqual(completed_ids, [self.EXP_ID_0])
+
+    def test_marking_incomplete_does_not_affect_completed_list(self) -> None:
+
+        learner_progress_services.mark_exploration_as_completed(
+            self.user_id, self.EXP_ID_0
+        )
+        self.assertEqual(
+            self._get_all_completed_exp_ids(self.user_id), [self.EXP_ID_0]
+        )
+
+        # Attempt to mark the already-completed exploration as incomplete.
+        learner_progress_services.mark_exploration_as_incomplete(
+            self.user_id, self.EXP_ID_0, 'some_state', 1
+        )
+
+        # Completed list should be unchanged.
+        self.assertEqual(
+            self._get_all_completed_exp_ids(self.user_id), [self.EXP_ID_0]
+        )
+        # Incomplete list should remain empty.
+        self.assertEqual(self._get_all_incomplete_exp_ids(self.user_id), [])
+
+    def test_incomplete_details_update_across_sessions(self) -> None:
+
+        learner_progress_services.mark_exploration_as_incomplete(
+            self.user_id, self.EXP_ID_0, 'first_state', 1
+        )
+        self.assertEqual(
+            self._get_all_incomplete_exp_ids(self.user_id), [self.EXP_ID_0]
+        )
+
+        # Simulate returning in a later session at a different state/version.
+        learner_progress_services.mark_exploration_as_incomplete(
+            self.user_id, self.EXP_ID_0, 'second_state', 2
+        )
+
+        # Should still be only one entry, not two.
+        self.assertEqual(
+            self._get_all_incomplete_exp_ids(self.user_id), [self.EXP_ID_0]
+        )
+
+        # Details should reflect the latest session.
+        details = self._get_incomplete_exp_details(self.user_id, self.EXP_ID_0)
+        self.assertEqual(details['state_name'], 'second_state')
+        self.assertEqual(details['version'], 2)
+
     def test_mark_collection_as_incomplete(self) -> None:
         self.assertEqual(
             self._get_all_incomplete_collection_ids(self.user_id), []


### PR DESCRIPTION
Overview

This PR fixes part of #2.

This PR does the following:
Adds three new backend unit tests to the LearnerProgressTests class in core/domain/learner_progress_services_test.py to cover edge cases in learner progress tracking that were previously untested. Specifically, it adds tests for:

test_completing_exploration_twice_does_not_duplicate_it

test_marking_incomplete_does_not_affect_completed_list

test_incomplete_details_update_across_sessions

These tests ensure that learner progress state remains consistent across repeated completions, incomplete transitions, and session updates, preventing subtle regressions in progress tracking logic.

Essential Checklist

 I have linked the issue that this PR fixes in the "Development" section of the sidebar.

 I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.

 I have written tests for my code.

 The PR title starts with "Fix part of #2: ...", followed by a short, clear summary of the changes.

 I have assigned the correct reviewers to this PR (or will leave a comment with "@<reviewer_username> PTAL" if I can't assign them directly).

Proof that changes are correct

No proof of UI changes is required because this PR only adds backend unit tests and does not modify any production logic or user-facing functionality.

All new tests pass locally, and existing tests continue to pass, confirming that no regressions were introduced.