### PR TITLE
630:P3 #33 Introduce EmailFacade to eliminate Shotgun Surgery in serv…

### DIFF
--- a/core/controllers/cron.py
+++ b/core/controllers/cron.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from core import feconf
 from core.constants import constants
 from core.controllers import acl_decorators, base
+from core.controllers import email_facade
 from core.domain import (
     app_feedback_report_services,
     beam_job_services,
@@ -128,12 +129,7 @@ class CronMailReviewersContributorDashboardSuggestionsHandler(
         """
         # Only execute this job if it's possible to send the emails and there
         # are reviewers to notify.
-        server_can_send_emails = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
-            )
-        )
-        if not server_can_send_emails:
+        if not email_facade.EmailFacade.can_send_emails():
             return self.render_json({})
         if not platform_parameter_services.get_platform_parameter_value(
             platform_parameter_list.ParamName.CONTRIBUTOR_DASHBOARD_REVIEWER_EMAILS_IS_ENABLED.value
@@ -170,12 +166,7 @@ class CronMailAdminContributorDashboardBottlenecksHandler(
         to alert the admins that specific suggestions have been waiting too long
         to get reviewed.
         """
-        server_can_send_emails = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
-            )
-        )
-        if not server_can_send_emails:
+        if not email_facade.EmailFacade.can_send_emails():
             return self.render_json({})
 
         admin_ids = user_services.get_user_ids_by_role(
@@ -234,12 +225,7 @@ class CronMailReviewerNewSuggestionsHandler(
         """Sends email notifications to reviewers about new
         suggestions on the Contributor Dashboard.
         """
-        server_can_send_emails = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
-            )
-        )
-        if not server_can_send_emails:
+        if not email_facade.EmailFacade.can_send_emails():
             return self.render_json({})
 
         if not platform_parameter_services.get_platform_parameter_value(
@@ -400,12 +386,7 @@ class CronMailChapterPublicationsNotificationsHandler(
         and upcoming (within CHAPTER_PUBLICATION_NOTICE_PERIOD_IN_DAYS days)
         chapter launches.
         """
-        server_can_send_emails = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
-            )
-        )
-        if not server_can_send_emails:
+        if not email_facade.EmailFacade.can_send_emails():
             return self.render_json({})
 
         admin_ids = user_services.get_user_ids_by_role(

--- a/core/controllers/email_facade.py
+++ b/core/controllers/email_facade.py
@@ -1,0 +1,49 @@
+# Copyright 2024 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Facade for email-sending operations (630:P3 Issue #33).
+
+Centralises the server_can_send_emails guard so that callers do not
+need to reach into platform_parameter_services directly.  Before this
+facade existed, every controller that wanted to send an email had to
+repeat the same three-line platform-parameter lookup (Shotgun Surgery).
+Now they call EmailFacade.can_send_emails() instead.
+"""
+
+from __future__ import annotations
+
+from core.domain import platform_parameter_list
+from core.domain import platform_parameter_services
+
+
+class EmailFacade:
+    """Facade that simplifies email availability checks for controllers.
+
+    Provides a single, stable interface over the underlying
+    platform_parameter_services so that controllers are decoupled from
+    the detail of how the server-can-send-emails flag is stored and
+    retrieved.
+    """
+
+    @staticmethod
+    def can_send_emails() -> bool:
+        """Returns True if the server is configured to send emails.
+
+        Returns:
+            bool. Whether the SERVER_CAN_SEND_EMAILS platform parameter
+            is currently enabled.
+        """
+        return platform_parameter_services.get_platform_parameter_value(
+            platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
+        )

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -25,6 +25,7 @@ import zipfile
 from core import feconf, utils
 from core.constants import constants
 from core.controllers import acl_decorators, base
+from core.controllers import email_facade
 from core.domain import (
     email_manager,
     platform_parameter_list,
@@ -535,14 +536,9 @@ class SignupHandler(
         """Handles GET requests."""
         assert self.user_id is not None
         user_settings = user_services.get_user_settings(self.user_id)
-        server_can_send_emails = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
-            )
-        )
         self.render_json(
             {
-                'server_can_send_emails': server_can_send_emails,
+                'server_can_send_emails': email_facade.EmailFacade.can_send_emails(),
                 'has_agreed_to_latest_terms': bool(
                     user_settings.last_agreed_to_terms
                     and user_settings.last_agreed_to_terms
@@ -614,12 +610,7 @@ class SignupHandler(
 
         # Note that an email is only sent when the user registers for the first
         # time.
-        server_can_send_emails = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
-            )
-        )
-        if server_can_send_emails and not has_ever_registered:
+        if email_facade.EmailFacade.can_send_emails() and not has_ever_registered:
             email_manager.send_post_signup_email(self.user_id)
 
         user_settings = user_services.get_user_settings(self.user_id)

--- a/core/controllers/topic_viewer.py
+++ b/core/controllers/topic_viewer.py
@@ -21,6 +21,7 @@ import logging
 from core import feconf, utils
 from core.constants import constants
 from core.controllers import acl_decorators, base
+from core.controllers import email_facade
 from core.domain import (
     classroom_config_services,
     email_manager,
@@ -145,10 +146,7 @@ class TopicPageDataHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
                 'The deleted skills: %s are still present in topic with id %s'
                 % (deleted_skills_string, topic.id)
             )
-            server_can_send_emails = platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
-            )
-            if server_can_send_emails:
+            if email_facade.EmailFacade.can_send_emails():
                 email_manager.send_mail_to_admin(
                     'Deleted skills present in topic',
                     'The deleted skills: %s are still present in topic with '


### PR DESCRIPTION
Closes #33

## Problem
The three-line server_can_send_emails platform parameter lookup was
duplicated in 7 places across 3 controller files (cron.py, profile.py,
topic_viewer.py). Every time the flag name, lookup method, or parameter
structure changed, all 7 call sites needed updating — a classic
Shotgun Surgery anti-pattern.

## Approach
Introduced the Facade (Structural) design pattern:
- New file: core/controllers/email_facade.py
- EmailFacade class with a single static method: can_send_emails()
- Encapsulates the platform_parameter_services lookup behind a stable interface
- All 7 call sites replaced with: email_facade.EmailFacade.can_send_emails()

## Anti-pattern removed
Shotgun Surgery — a single conceptual change (checking email availability)
was scattered across 7 locations in 3 files.

## Pattern applied
Facade (Structural) — a single class provides a simplified interface over
the platform_parameter_services subsystem for email availability checks.
Future changes to how email availability is determined require edits in
exactly one place.

## Evidence
- Before: 7 identical 3-line blocks across cron.py, profile.py, topic_viewer.py
- After: 1 method in EmailFacade, 7 single-line call sites
- Lines removed: 40 | Lines added: 59 (including full facade module with docs)

## Verification
- Baseline: 151 tests passing before changes
- After: 151 tests passing — no regressions
- cron_test/profile_test have pre-existing import errors in local env
  (present on develop before branching, unrelated to this change)